### PR TITLE
Merlin is working on 2.5

### DIFF
--- a/bin/preinstall.bat
+++ b/bin/preinstall.bat
@@ -13,7 +13,8 @@ REM Configure opam
 set "bashcmd=%bashcmd%; opam init --auto-setup --dot-profile=~/.bashrc"
 set "bashcmd=%bashcmd%; opam update"
 set "bashcmd=%bashcmd%; opam switch 4.02.3"
-set "bashcmd=%bashcmd%; opam install -y reason merlin"
+set "bashcmd=%bashcmd%; opam install -y reason"
+set "bashcmd=%bashcmd%; opam install -y merlin.2.5.4"
 
 REM Install nodejs
 set "bashcmd=%bashcmd%; curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -"


### PR DESCRIPTION
Until further information on how to make Merlin 3.0.3 work, let's leave it this way.